### PR TITLE
set and assert env vars are correct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+JAVA_HOME := $(GRAALVM_HOME)
+PATH := $(GRAALVM_HOME)/bin:$(shell echo $$PATH)
+LLVM_TOOLCHAIN := $(shell $(GRAALVM_HOME)/bin/lli --print-toolchain-path)
 UNAME := $(shell uname)
 
 ifeq ($(UNAME), Linux)
@@ -18,14 +21,14 @@ info:
 	native-image --expert-options-all
 
 sdl-bindings:
-	lein exec -ep "(require '[clobits.examples.sdl.create-sdl-lib]) (clobits.examples.sdl.create-sdl-lib/-main)"
+	LLVM_TOOLCHAIN=${LLVM_TOOLCHAIN} lein exec -ep "(require '[clobits.examples.sdl.create-sdl-lib]) (clobits.examples.sdl.create-sdl-lib/-main)"
 	-rm -r target
 
 ncurses-bindings:
-	lein exec -ep "(require '[clobits.examples.ncurses.create-ncurses-lib]) (clobits.examples.ncurses.create-ncurses-lib/-main)"
+	LLVM_TOOLCHAIN=${LLVM_TOOLCHAIN} lein exec -ep "(require '[clobits.examples.ncurses.create-ncurses-lib]) (clobits.examples.ncurses.create-ncurses-lib/-main)"
 	-rm -r target
 
-bindings: sdl-bindings ncurses-bindings
+bindings: assert-graal assert-clang sdl-bindings ncurses-bindings
 
 sdl-poly: bindings
 	lein with-profiles $(OSFLAG),+sdl-poly do clean, run
@@ -38,3 +41,12 @@ sdl-ni: bindings
 
 ncurses-ni: bindings
 	NATIVE_IMAGE=true NI_EXAMPLE=ncurses ./compile && LD_LIBRARY_PATH=./libs ./ncurses_example
+
+assert-graal:
+	@ if [ "${GRAALVM_HOME}" = "" ]; then \
+		echo "\n  Error: You must set or pass in the GRAALVM_HOME environment variable.\n"; \
+		exit 1; \
+	fi
+
+assert-clang:
+	${LLVM_TOOLCHAIN}/clang --version

--- a/README.md
+++ b/README.md
@@ -46,11 +46,9 @@ If you know how to solve the problems below, please tell me how! :) Either throu
 
 * graalvm -- tested with `graalvm-ce-java11-20.2.0-dev`: https://github.com/graalvm/graalvm-ce-dev-builds/releases
   * download, then add the following to e.g. .zprofile
-  * `export GRAALVM_HOME = "/path/to/graalvm-ce-java11-20.2.0-dev/Contents/Home/"`
-  * `export JAVA_HOME = $GRAALVM_HOME`
+  * `export GRAALVM_HOME="/path/to/graalvm-ce-java11-20.2.0-dev/Contents/Home/"`
 * install native-image: `$GRAALVM_HOME/bin/gu install native-image` (will be installed by `./compile` otherwise)
-* llvm toolchain -- https://www.graalvm.org/docs/reference-manual/languages/llvm/
-  * export LLVM_TOOLCHAIN as in the instructions
+* install llvm toolchain: `$GRAALVM_HOME/bin/gu install llvm-toolchain`
 * leiningen -- https://leiningen.org/
 
 Tested on macos and linux.


### PR DESCRIPTION
Are you using a mac? Please chack this works on the mac. It should.

With no env set:

```
crispin@vash:~/dev/epiccastle/clobits$ unset JAVA_HOME
crispin@vash:~/dev/epiccastle/clobits$ unset GRAALVM_HOME
crispin@vash:~/dev/epiccastle/clobits$ unset LLVM_TOOLCHAIN
crispin@vash:~/dev/epiccastle/clobits$ make clean sdl-poly
make: /bin/lli: Command not found
rm sdl_example
rm: cannot remove 'sdl_example': No such file or directory
Makefile:15: recipe for target 'clean' failed
make: [clean] Error 1 (ignored)
rm -r src/bindings
rm -r target
rm -r libs/*

  Error: You must set or pass in the GRAALVM_HOME environment variable.

Makefile:46: recipe for target 'assert-graal' failed
make: *** [assert-graal] Error 1
```

with GRAALVM_HOME as environment var

```
crispin@vash:~/dev/epiccastle/clobits$ export GRAALVM_HOME=/home/crispin/graalvm-ce-java11-20.1.0/
crispin@vash:~/dev/epiccastle/clobits$ make clean sdl-poly
rm sdl_example
rm: cannot remove 'sdl_example': No such file or directory
Makefile:15: recipe for target 'clean' failed
make: [clean] Error 1 (ignored)
rm -r src/bindings
rm: cannot remove 'src/bindings': No such file or directory
Makefile:15: recipe for target 'clean' failed
make: [clean] Error 1 (ignored)
rm -r target
rm: cannot remove 'target': No such file or directory
Makefile:15: recipe for target 'clean' failed
make: [clean] Error 1 (ignored)
rm -r libs/*
rm: cannot remove 'libs/*': No such file or directory
Makefile:15: recipe for target 'clean' failed
make: [clean] Error 1 (ignored)
/home/crispin/graalvm-ce-java11-20.1.0/languages/llvm/native/bin/clang --version
clang version 9.0.0 (GraalVM.org llvmorg-9.0.0-5-g80b1d876fd-bgb66b241662 80b1d876fd4296b48433de5b66eaebe551897508)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /home/crispin/graalvm-ce-java11-20.1.0/lib/llvm/bin
LLVM_TOOLCHAIN=/home/crispin/graalvm-ce-java11-20.1.0/languages/llvm/native/bin lein exec -ep "(require '[clobits.examples.sdl.create-sdl-lib]) (clobits.examples.sdl.create-sdl-lib/-main)"
OpenJDK 64-Bit Server VM warning: forcing TieredStopAtLevel to full optimization because JVMCI is enabled
Creating libs
Generating bindings.sdl
Creating dir #object[java.io.File 0x671facee /home/crispin/dev/epiccastle/clobits/src]
Creating dir #object[java.io.File 0x46a953cf /home/crispin/dev/epiccastle/clobits/src/bindings]
Creating dir #object[java.io.File 0x154bd49b /home/crispin/dev/epiccastle/clobits/src]
Creating dir #object[java.io.File 0x3a01773b /home/crispin/dev/epiccastle/clobits/src/bindings]
Spitting c-code: // includes
#include "sdl.h"

// inline-c
int GET_SDL_INIT_VIDEO() { return SDL_INIT_VIDEO; }
int GE ...

Spitting h-code: #if IS_POLYGLOT
#include <polyglot.h>
#endif
#include <stdio.h>
#include <SDL2/SDL.h>

int  _SHADOWI ...

Compilation results:
{:exit 0, :out , :err src/bindings/sdl.c:72:11: warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
 title634 = title;
          ^ ~~~~~
1 warning generated.
}
{:exit 0, :out , :err }
Creating dir #object[java.io.File 0x5477a1ca /home/crispin/dev/epiccastle/clobits/src]
Creating dir #object[java.io.File 0x3ae9d1e2 /home/crispin/dev/epiccastle/clobits/src/bindings]
Persisting clj to: src/bindings/sdl_ns.clj
Done!
rm -r target
LLVM_TOOLCHAIN=/home/crispin/graalvm-ce-java11-20.1.0/languages/llvm/native/bin lein exec -ep "(require '[clobits.examples.ncurses.create-ncurses-lib]) (clobits.examples.ncurses.create-ncurses-lib/-main)"
OpenJDK 64-Bit Server VM warning: forcing TieredStopAtLevel to full optimization because JVMCI is enabled
Creating libs
Generating bindings.ncurses
Creating dir #object[java.io.File 0xf288c14 /home/crispin/dev/epiccastle/clobits/src]
Creating dir #object[java.io.File 0x6794ac0b /home/crispin/dev/epiccastle/clobits/src/bindings]
Creating dir #object[java.io.File 0x7be71476 /home/crispin/dev/epiccastle/clobits/src]
Creating dir #object[java.io.File 0x5cb5bb88 /home/crispin/dev/epiccastle/clobits/src/bindings]
Spitting c-code: // includes
#include "ncurses.h"

// inline-c


// fns
void  _SHADOWING_free( void * ptr) {
  free(p ...

Spitting h-code: #if IS_POLYGLOT
#include <polyglot.h>
#endif
#include <ncurses.h>
#include <stdlib.h>
#include <stri ...

Compilation results:
{:exit 0, :out , :err }
{:exit 0, :out , :err }
Creating dir #object[java.io.File 0x4d1f1ff5 /home/crispin/dev/epiccastle/clobits/src]
Creating dir #object[java.io.File 0x222afc67 /home/crispin/dev/epiccastle/clobits/src/bindings]
Persisting clj to: src/bindings/ncurses_ns.clj
Done!
rm -r target
lein with-profiles +linux,+sdl-poly do clean, run
OpenJDK 64-Bit Server VM warning: forcing TieredStopAtLevel to full optimization because JVMCI is enabled
In polyglot context
WARNING: delay already refers to: #'clojure.core/delay in namespace: bindings.sdl-ns, being replaced by: #'bindings.sdl-ns/delay
rgb1 16777215
rgb2 16711680
```

Overriding GRAALVM_HOME on make line with graal that has no llvm installed

```
crispin@vash:~/dev/epiccastle/clobits$ make clean sdl-poly GRAALVM_HOME=/home/crispin/graalvm-ce-java11-20.2.0-devrm sdl_example
rm: cannot remove 'sdl_example': No such file or directory
Makefile:15: recipe for target 'clean' failed
make: [clean] Error 1 (ignored)
rm -r src/bindings
rm -r target
rm -r libs/*
/home/crispin/graalvm-ce-java11-20.2.0-dev/languages/llvm/native/bin/clang --version
Tool execution failed. Are you sure the toolchain is available at /home/crispin/graalvm-ce-java11-20.2.0-dev/lib/llvm
You can install it via GraalVM updater: `gu install llvm-toolchain`

More infos: https://www.graalvm.org/docs/reference-manual/languages/llvm/
Makefile:52: recipe for target 'assert-clang' failed
make: *** [assert-clang] Error 1

```